### PR TITLE
Improvement: remove 65330/udp from user assign port in Windows2022jp

### DIFF
--- a/images/windows2022image.bicep
+++ b/images/windows2022image.bicep
@@ -49,14 +49,6 @@ resource ws2022ImageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2024
         sha256Checksum: '7148640bccbc7b0a99975cbc006c1087f13bc31106b9abfe21fa8a301e7ed552'
       }
       {
-        name: 'Install Japanese Language Pack'
-        type: 'PowerShell'
-        runElevated: true
-        inline: [
-          'Install-Language -Language ja-JP'
-        ]
-      }
-      {
         name: 'remove 65330/udp port'
         type: 'PowerShell'
         runElevated: true

--- a/images/windows2022image.bicep
+++ b/images/windows2022image.bicep
@@ -72,14 +72,6 @@ resource ws2022ImageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2024
         runElevated: true
       }
       {
-        name: 'exclude 65330/udp port'
-        type: 'PowerShell'
-        runElevated: true
-        inline: [
-          'Install-Language -Language ja-JP'
-        ]
-      }
-      {
         type: 'WindowsRestart'
         restartTimeout: '5m'
       }

--- a/images/windows2022image.bicep
+++ b/images/windows2022image.bicep
@@ -49,6 +49,14 @@ resource ws2022ImageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2024
         sha256Checksum: '7148640bccbc7b0a99975cbc006c1087f13bc31106b9abfe21fa8a301e7ed552'
       }
       {
+        name: 'Install Japanese Language Pack'
+        type: 'PowerShell'
+        runElevated: true
+        inline: [
+          'Install-Language -Language ja-JP'
+        ]
+      }
+      {
         name: 'remove 65330/udp port'
         type: 'PowerShell'
         runElevated: true
@@ -57,7 +65,14 @@ resource ws2022ImageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2024
         ]
       }
       {
-        name: 'install language pack'
+        type: 'PowerShell'
+        name: 'InstallLanguagePack'
+        scriptUri: 'https://raw.githubusercontent.com/kkamegawa/windowsjpimagebuilder/main/images/Windows2022/install-jplangpack.ps1'
+        sha256Checksum: '7aa9fff747d6fd19bb47d108b9ba4f014ce219bbd124d959d93148756143b83f'
+        runElevated: true
+      }
+      {
+        name: 'exclude 65330/udp port'
         type: 'PowerShell'
         runElevated: true
         inline: [
@@ -70,7 +85,7 @@ resource ws2022ImageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2024
       }
       {
         type: 'PowerShell'
-        name: 'Setup default language(ja-jp)'
+        name: 'InstallLanguagePack'
         scriptUri: 'https://raw.githubusercontent.com/kkamegawa/windowsjpimagebuilder/main/images/Windows2022/install-languagepack.ps1'
         sha256Checksum: 'b927319850cecb2fb87827b5e4d20f997e90b12fce053192e883b9385c4efc42'
         runElevated: true

--- a/images/windows2022image.bicep
+++ b/images/windows2022image.bicep
@@ -26,7 +26,7 @@ param date string = utcNow('yyyy.MM.ddHHmm')
 
 var galleyImageVersion = '${gal.id}/versions/${date}'
 
-resource ws2022ImageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2023-07-01' = {
+resource ws2022ImageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2024-02-01' = {
   name: imageTemplateName
   location: location
   tags: {
@@ -49,11 +49,35 @@ resource ws2022ImageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2023
         sha256Checksum: '7148640bccbc7b0a99975cbc006c1087f13bc31106b9abfe21fa8a301e7ed552'
       }
       {
+        name: 'Install Japanese Language Pack'
+        type: 'PowerShell'
+        runElevated: true
+        inline: [
+          'Install-Language -Language ja-JP'
+        ]
+      }
+      {
+        name: 'remove 65330/udp port'
+        type: 'PowerShell'
+        runElevated: true
+        inline: [
+          'netsh int ipv4 add excludedportrange udp 65330 1 persistent'
+        ]
+      }
+      {
         type: 'PowerShell'
         name: 'InstallLanguagePack'
         scriptUri: 'https://raw.githubusercontent.com/kkamegawa/windowsjpimagebuilder/main/images/Windows2022/install-jplangpack.ps1'
         sha256Checksum: '7aa9fff747d6fd19bb47d108b9ba4f014ce219bbd124d959d93148756143b83f'
         runElevated: true
+      }
+      {
+        name: 'exclude 65330/udp port'
+        type: 'PowerShell'
+        runElevated: true
+        inline: [
+          'Install-Language -Language ja-JP'
+        ]
       }
       {
         type: 'WindowsRestart'

--- a/images/windows2022image.bicep
+++ b/images/windows2022image.bicep
@@ -49,14 +49,6 @@ resource ws2022ImageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2024
         sha256Checksum: '7148640bccbc7b0a99975cbc006c1087f13bc31106b9abfe21fa8a301e7ed552'
       }
       {
-        name: 'Install Japanese Language Pack'
-        type: 'PowerShell'
-        runElevated: true
-        inline: [
-          'Install-Language -Language ja-JP'
-        ]
-      }
-      {
         name: 'remove 65330/udp port'
         type: 'PowerShell'
         runElevated: true
@@ -65,14 +57,7 @@ resource ws2022ImageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2024
         ]
       }
       {
-        type: 'PowerShell'
-        name: 'InstallLanguagePack'
-        scriptUri: 'https://raw.githubusercontent.com/kkamegawa/windowsjpimagebuilder/main/images/Windows2022/install-jplangpack.ps1'
-        sha256Checksum: '7aa9fff747d6fd19bb47d108b9ba4f014ce219bbd124d959d93148756143b83f'
-        runElevated: true
-      }
-      {
-        name: 'exclude 65330/udp port'
+        name: 'install language pack'
         type: 'PowerShell'
         runElevated: true
         inline: [
@@ -85,7 +70,7 @@ resource ws2022ImageTemplate 'Microsoft.VirtualMachineImages/imageTemplates@2024
       }
       {
         type: 'PowerShell'
-        name: 'InstallLanguagePack'
+        name: 'Setup default language(ja-jp)'
         scriptUri: 'https://raw.githubusercontent.com/kkamegawa/windowsjpimagebuilder/main/images/Windows2022/install-languagepack.ps1'
         sha256Checksum: 'b927319850cecb2fb87827b5e4d20f997e90b12fce053192e883b9385c4efc42'
         runElevated: true


### PR DESCRIPTION
This pull request includes updates to the `images/windows2022image.bicep` file to modify the image template version and add a new PowerShell script. The most important changes are as follows:

Updates to image template:

* Changed the `ws2022ImageTemplate` resource to use `Microsoft.VirtualMachineImages/imageTemplates@2024-02-01` instead of `@2023-07-01`. (`images/windows2022image.bicep`)

New PowerShell script:

* Added a new PowerShell script to remove the 65330/udp port by adding it to the excluded port range. (`images/windows2022image.bicep`)